### PR TITLE
Revised deployment

### DIFF
--- a/serverless/README.md
+++ b/serverless/README.md
@@ -4,39 +4,41 @@ This reference template shows how you can build add a simple  moderation capabil
 
 ⚠️ **IMPORTANT NOTE:** *Deploying this demo application in your AWS account will create and consume AWS resources, which will cost money.*
 
+The moderation backend should be deployed in the same AWS region as your IVS control region (i.e. US West (Oregon), US East (N. Virginia) or Europe (Ireland))
+
 This project is set up like any standard Python project.  The initialization process also creates a virtualenv within this project, stored under the `.env` directory. To create the virtualenv it assumes that there is a `python3` (or `python` for Windows) executable in your path with access to the `venv` package. If for any reason the automatic creation of the virtualenv fails, you can create the virtualenv manually.
 
 To manually create a virtualenv on MacOS and Linux:
 
 ```
-$ python3 -m venv .env
+python3 -m venv .env
 ```
 
 After the init process completes and the virtualenv is created, you can use the following
 step to activate your virtualenv.
 
 ```
-$ source .env/bin/activate
+source .env/bin/activate
 ```
 
 If you are a Windows platform, you would activate the virtualenv like this:
 
 ```
-% .env\Scripts\activate.bat
+.env\Scripts\activate.bat
 ```
 
 Once the virtualenv is activated, you can install the required dependencies.
 
 ```
-$ pip install -r requirements.txt
+pip install -r requirements.txt
 ```
 
 At this point you can now synthesize the CloudFormation template for this code.
 
 ```
-$ cdk synth
+cdk synth
 ```
-Once the synthesize command is successful, you can deploy the backend using the deploy command.
+Once the synthesize command is successful, you can deploy the backend using the deploy command. **IMPORTANT:** Update the command to specify your email address 
 
 ```
 cdk deploy --parameters email=user@sample.com --outputs-file outputs.json
@@ -45,7 +47,7 @@ cdk deploy --parameters email=user@sample.com --outputs-file outputs.json
 * `outputs.json` file can be useful to run helper script to deploy the front-end.
 * `email` parameter is used for sending sns alerts when a new task is assigned to the moderation queue. 
 
-During the installation you should receive an email to subscribe to an SNS topic. You should accept the email.    
+During the installation you should receive an email to subscribe to an SNS topic. Acknowledge this by clicking the link the email.
 
 Once the installation is completed, note down the S3 bucket created. You should use this S3 bucket when you setup the recording configuration in Amazon IVS.
 

--- a/web-ui/README.md
+++ b/web-ui/README.md
@@ -2,18 +2,43 @@
 
 ## Updating Config Variables
 
-The variables in the file `config.js` are all currently empty and the developer will need to deploy the backend to their account. 
+The variables in the file `config.js` are initially empty. The developer will first need to deploy the backend to their account. This process writes the associated values to screen and to the outputs.json file once complete. They can also be retrieved from the AWS CloudFormation Console under the ivs-moderation stack's Outputs tab.
+
+The region value is set to us-west-2 (Oregon) by default. Change this to us-east-1 (N.Virginia) or eu-west-1 (Dublin) to match the region in which you deployed the backend.
+
+Once updated, the config.js file should look similar to this:
+
+```
+import Amplify from 'aws-amplify'
+
+export const awsConfig = {
+  Auth: {
+    identityPoolId: "us-west-2:5bccaac1-71ba-4927-b7f6-5cbecfa791ec",
+    region: "us-west-2", 
+    userPoolId: "us-west-2_gY10q8PuN", 
+    userPoolWebClientId: "5snlrgu90d2rf8eogk86rm4u5g",
+  },
+  aws_appsync_graphqlEndpoint: "https://kdmmol2h6jcxrivd6jpknopvni.appsync-api.us-west-2.amazonaws.com/graphql",
+  apiGateway: "https://juzgm32quj.execute-api.us-west-2.amazonaws.com/prod/",
+  aws_appsync_authenticationType: process.env.REACT_APP_AWS_APPSYNC_AUTHENTICATIONTYPE,
+}
+
+Amplify.configure(awsConfig)
+```
 
 ### For retrieving your `Auth` configs
 
-This project uses an existing backend with an Authentication, and this connection provided by Amplify.
+This project uses an existing backend with an Authentication. You can create new users via the web applications login prompt.
 
-For replacing the Auth config variables, you can either use the [Amplify CLI to add Authentication to the project](https://docs.amplify.aws/lib/auth/getting-started/q/platform/js#create-authentication-service),
-or [go to the console and access Cognito](https://docs.aws.amazon.com/cognito/latest/developerguide/cognito-console.html) to get the variables needed.
+### Connecting IVS Channels to the moderation workflow
 
-If you do not have an AWS account, please see [How do I create and activate a new Amazon Web Services account?](https://aws.amazon.com/premiumsupport/knowledge-center/create-and-activate-aws-account/)
-Log into the AWS console if you are not already. Note: If you are logged in as an IAM user, ensure your account has permissions to create and manage the necessary resources and components for this application.
-Follow the instructions for deploying to AWS or running locally.
+The moderation workflow is triggered as thumbnail images are written to the S3 bucket created by the backend deployment. IVS automatically creates these thumbnail images for channels configured to archive to S3. To add auto-recording to S3 to your IVS Channel:
+
+1. Create a recording configuration and specify the S3 bucket deployed by the backend (see _ivs-moderation.s3bucket_ in the output.json)
+2. The frequency at which images are processed for moderation is controlled by the _Target thumbnail interval_ setting in the recording configuration. Set this at the desired cadence.
+3. In the IVS Channel configuration page, enable Auto-record to S3 and select the recording configuration
+
+Refer to the [Create a Channel with Optional Recording](https://docs.aws.amazon.com/ivs/latest/userguide/getting-started-create-channel.html) documentation for additional information
 
 ### More information about other API endpoints
 

--- a/web-ui/src/configs/config.js
+++ b/web-ui/src/configs/config.js
@@ -2,14 +2,14 @@ import Amplify from 'aws-amplify'
 
 export const awsConfig = {
   Auth: {
-    identityPoolId: process.env.REACT_APP_IDENTITY_POOL_ID,
-    region: process.env.REACT_APP_REGION, 
-    userPoolId: process.env.REACT_APP_USER_POOL_ID, 
-    userPoolWebClientId: process.env.REACT_APP_USER_POOL_WEB_CLIENT_ID,
+    identityPoolId: "", 
+    userPoolId: "", 
+    userPoolWebClientId: "",
+    region: "us-west-2",
   },
-  aws_appsync_graphqlEndpoint: process.env.REACT_APP_AWS_APPSYNC_GRAPHQLENDPOINT,
-  apiGateway: process.env.REACT_APP_API_GATEWAY,
-  aws_appsync_authenticationType: process.env.REACT_APP_AWS_APPSYNC_AUTHENTICATIONTYPE,
+  aws_appsync_graphqlEndpoint: "",
+  apiGateway: "",
+  aws_appsync_authenticationType: "AMAZON_COGNITO_USER_POOLS",
 }
 
 Amplify.configure(awsConfig)


### PR DESCRIPTION
General updates to the deployment instructions in both the web-ui and serverless readme notes. 
Removed process.env values from the web-ui config.js and provided a completed example in the accompanying docs. 
Set default region to us-west-2, and updated docs. Region is not a value currently returned by the backend install. 
Added instructions for connecting an IVS channel to the moderation process.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
